### PR TITLE
Clean up `gsutil` output

### DIFF
--- a/mina-indexer-block-util/src/common.rs
+++ b/mina-indexer-block-util/src/common.rs
@@ -1,0 +1,16 @@
+use log::debug;
+use std::process::{self, Command};
+
+/// Check that gsutil is installed
+pub fn check_gsutil() {
+    debug!("Checking gsutil is installed...");
+    match Command::new("gsutil").arg("version").output() {
+        Ok(_) => (),
+        Err(_) => {
+            println!(
+                "Please install gsutil! See https://cloud.google.com/storage/docs/gsutil_install"
+            );
+            process::exit(2);
+        }
+    }
+}

--- a/mina-indexer-block-util/src/main.rs
+++ b/mina-indexer-block-util/src/main.rs
@@ -1,5 +1,6 @@
 use clap::{Parser, Subcommand};
 
+mod common;
 mod contiguous;
 mod continuous_loop;
 mod new_only;


### PR DESCRIPTION
- captures `gsutil` output and only shows desired lines
- adds `network` and `bucket` options to `contiguous` mode

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205103570662684